### PR TITLE
feat(logger): allow to set overall log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ module.exports.main = wrap(main)
 
 
 * [logger](#module_logger)
-    * [~init(params, [logger])](#module_logger..init) ⇒ <code>SimpleInterface</code>
+    * [~init(params, [logger], [level])](#module_logger..init) ⇒ <code>SimpleInterface</code>
     * [~trace(fn)](#module_logger..trace) ⇒ <code>ActionFunction</code>
     * [~logger(fn, [opts])](#module_logger..logger) ⇒ <code>ActionFunction</code>
 
 <a name="module_logger..init"></a>
 
-### logger~init(params, [logger]) ⇒ <code>SimpleInterface</code>
+### logger~init(params, [logger], [level]) ⇒ <code>SimpleInterface</code>
 Initializes helix-log that adds additional activation related fields to the loggers.
 It also looks for credential params and tries to add additional external logger
 (eg. coralogix, papertrail).
@@ -55,6 +55,7 @@ It also initializes `params.__ow_logger` with a SimpleInterface if not already p
 | --- | --- | --- | --- |
 | params | <code>\*</code> |  | openwhisk action params. |
 | [logger] | <code>MultiLogger</code> | <code>rootLogger</code> | a helix multi logger. defaults to the helix                                            `rootLogger`. |
+| [level] | <code>string</code> |  | Overall log-level. defaults to `params.LOG_LEVEL` or 'info`. |
 
 <a name="module_logger..trace"></a>
 

--- a/src/logger.d.ts
+++ b/src/logger.d.ts
@@ -27,6 +27,11 @@ declare interface WrapOptions {
    * Additional fields to log with the `ow` logging fields.
    */
   fields?: object,
+
+  /**
+   * Overall log level. defaults to `params.LOG_LEVEL` or 'info`
+   */
+  level?: string,
 }
 
 /**
@@ -65,9 +70,10 @@ export declare namespace logger {
    * @param {*} params - openwhisk action params.
    * @param {MultiLogger} [logger=rootLogger] - a helix multi logger. defaults to the helix
    *                                            `rootLogger`.
+   * @param {string} level - Overall log-level. defaults to `params.LOG_LEVEL` or 'info`.
    * @returns BunyanLogger a bunyan logger.
    */
-  export function init(params: object, logger: MultiLogger): SimpleInterface;
+  export function init(params: object, logger: MultiLogger, level?: string): SimpleInterface;
 
   /**
    * Creates a tracer function that logs invocation details on `trace` level before and after the


### PR DESCRIPTION
fixes #32

Adds a new `level` parameter to `init()` and `logger()` that can set the overall log-level. 
if none specified it falls back to `params.LOG_LEVEL` and eventually to `info`.